### PR TITLE
Add quotes definitions for Czech language.

### DIFF
--- a/typo.el
+++ b/typo.el
@@ -98,7 +98,9 @@
   :group 'convenience)
 
 (defcustom typo-quotation-marks
-  '(("English"               "“" "”" "‘" "’")
+  '(("Czech"                 "„" "“" "‚" "‘")
+    ("Czech (Guillemets)"    "»" "«" "›" "‹")
+    ("English"               "“" "”" "‘" "’")
     ("German"                "„" "“" "‚" "‘")
     ("German (Guillemets)"   "»" "«" "›" "‹")
     ("French"                "«" "»" "‹" "›")


### PR DESCRIPTION
Here is patch that adds Czech language quotes to typo.el.

I have not realised this before but it appears that the quotation marks are the same in German and in Czech languages.