### PR TITLE
Add Italian quotation marks

### DIFF
--- a/typo.el
+++ b/typo.el
@@ -109,7 +109,7 @@
     ("Finnish"               "”" "”" "’" "’")
     ("Finnish (Guillemets)"  "»" "»" "›" "›")
     ("Russian"               "«" "»" "„" "“")
-    )
+    ("Italian"               "«" "»" "“" "”"))
   "*Quotation marks per language."
   :type '(repeat (list (string :tag "Language")
                        (string :tag "Double Opening Quotation Mark")


### PR DESCRIPTION
I added the quotation marks for the Italian language.

I used [this table](https://en.wikipedia.org/wiki/Quotation_mark#Summary_table_for_all_languages) as a reference.