### PR TITLE
Add ‘indent’ and ‘doc-string’ declarations to ‘define-typo-cycle’.

### DIFF
--- a/typo.el
+++ b/typo.el
@@ -355,6 +355,7 @@ NAME is the name of the command to define.
 DOCSTRING is the docstring for that command.
 
 CYCLE is a list of strings to cycle through."
+  (declare (indent 1) (doc-string 2))
   `(defun ,name (arg)
      ,docstring
      (interactive "P")


### PR DESCRIPTION
These ensure the defined name is distinguished by its indentation, and
the doc string is font-locked with ‘font-lock-doc-face’.