### PR TITLE
Add simpler logic for languages using same open and close quote

### DIFF
--- a/typo.el
+++ b/typo.el
@@ -104,10 +104,9 @@
     ("German"                "„" "“" "‚" "‘")
     ("German (Guillemets)"   "»" "«" "›" "‹")
     ("French"                "«" "»" "‹" "›")
-    ;; Finnish does not work THAT well because they use the same
-    ;; quotation mark on both sides. En ymmärrä suomalaisen.
     ("Finnish"               "”" "”" "’" "’")
     ("Finnish (Guillemets)"  "»" "»" "›" "›")
+    ("Swedish"               "”" "”" "’" "’")
     ("Russian"               "«" "»" "„" "“")
     ("Italian"               "«" "»" "“" "”"))
   "*Quotation marks per language."
@@ -302,6 +301,11 @@ marks will be inserted."
           (after-any-opening (looking-back (regexp-opt (list double-open
                                                              single-open)))))
      (cond
+      ;; For languages that use the same symbol for opening and
+      ;; closing (Finnish, Swedish...), the simplest thing to do is to
+      ;; not try to be too smart and just cycle ” and "
+      ((equal double-open double-close)
+       (typo-insert-cycle (list double-open "\"")))
       ;; Inside a single quotation, if we're not directly at the
       ;; opening one, we close it.
       ((and single-needs-closing


### PR DESCRIPTION
This works well for the case of Finnish and Swedish where we use:
("”" "”" "’" "’")

Now, invoking typo-insert-quotation-mark with " cycles between
opening-double-quote and typewriter quote, and for using single
quotes, Swedish and Finnish writers can use ' to invoke
typo-cycle-right-single-quotation-mark (which will be the right symbol
for these languages).

This does not add a good insertion method for possible other (identical opening and closing) single quotes in other languages.

Additionally add an entry for Swedish.


----

#