### PR TITLE
Add Serbian language

### DIFF
--- a/typo.el
+++ b/typo.el
@@ -109,7 +109,8 @@
     ("Swedish"               "”" "”" "’" "’")
     ("Russian"               "«" "»" "„" "“")
     ("Italian"               "«" "»" "“" "”")
-    ("Polish"                "„" "”" "‚" "’"))
+    ("Polish"                "„" "”" "‚" "’")
+    ("Serbian"               "„" "”" "’" "’"))
   "*Quotation marks per language."
   :type '(repeat (list (string :tag "Language")
                        (string :tag "Double Opening Quotation Mark")


### PR DESCRIPTION
Double quotation marks in Serbian starts with lower and ends with upper quotes, but single quotation marks are both upper.